### PR TITLE
Don't crash when the Firefall patch servers are offline.

### DIFF
--- a/Meldii/Meldii.DataStructures/FirefallPatchData.cs
+++ b/Meldii/Meldii.DataStructures/FirefallPatchData.cs
@@ -9,11 +9,19 @@ namespace Meldii.DataStructures
         public string environment;
         public string region;
         public string patch_level;
+        public bool error;
 
         public static FirefallPatchData Create(Stream data)
         {
             DataContractJsonSerializer serializer = new DataContractJsonSerializer(typeof(FirefallPatchData));
             return (FirefallPatchData)serializer.ReadObject(data);
+        }
+
+        public static FirefallPatchData CreateError()
+        {
+            FirefallPatchData r = new FirefallPatchData();
+            r.error = true;
+            return r;
         }
     }
 }

--- a/Meldii/Statics.cs
+++ b/Meldii/Statics.cs
@@ -182,9 +182,16 @@ namespace Meldii
             {
                 using (WebClient wc = new WebClient())
                 {
-                    using (Stream s = GenerateStreamFromString(wc.DownloadString("http://operator.firefallthegame.com/api/v1/products/Firefall_Beta")))
+                    try
                     {
-                        FirefallPatchData = FirefallPatchData.Create(s);
+                        using (Stream s = GenerateStreamFromString(wc.DownloadString("http://operator.firefallthegame.com/api/v1/products/Firefall_Beta")))
+                        {
+                            FirefallPatchData = FirefallPatchData.Create(s);
+                        }
+                    }
+                    catch (System.Net.WebException)
+                    {
+                        FirefallPatchData = FirefallPatchData.CreateError();
                     }
                 }
             }


### PR DESCRIPTION
A better implementation could be provided.  This just lets Meldii launch without spewing errors everywhere.
