### PR TITLE
Remove sources of exceptions in the constructor

### DIFF
--- a/Meldii/MainWindow.xaml.cs
+++ b/Meldii/MainWindow.xaml.cs
@@ -38,18 +38,19 @@ namespace Meldii
             if (Statics.NeedAdmin())
                 Statics.RunAsAdmin(Statics.LaunchArgs);
 
-            ViewModel = new MainViewModel();
-
             this.AddHandler(MetroWindow.DragOverEvent, new DragEventHandler(OnFileDragOver), true);
             this.AddHandler(MetroWindow.DropEvent, new DragEventHandler(OnFileDrop), true);
         }
 
         private void MetroWindow_Loaded(object sender, RoutedEventArgs e)
         {
-            DataContext = ViewModel;
+            ViewModel = new MainViewModel();
             AddonManager = new AddonManager(ViewModel);
+
+            DataContext = ViewModel;
             Statics.AddonManager = AddonManager;
 
+            Statics.GetFirefallPatchData();
             SelfUpdater.ThreadUpdateAndCheck();
         }
 

--- a/Meldii/Statics.cs
+++ b/Meldii/Statics.cs
@@ -58,7 +58,6 @@ namespace Meldii
             }
 
             AddonsFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), @"Firefall\Addons");
-            GetFirefallPatchData();
         }
 
         public static string FixPathSlashes(string str)


### PR DESCRIPTION
This moves some functions known to cause exceptions to the MainWindow_Loaded function.  The exception logs are easier to decipher if the code fails there.
