### PR TITLE
Better update handling for Steam + standard installs.

### DIFF
--- a/Meldii/SelfUpdater.cs
+++ b/Meldii/SelfUpdater.cs
@@ -69,8 +69,8 @@ namespace Meldii
 
         private static async void UpdateChecks()
         {
-            // If we aren't using a Steam install, check for a Firefall update.
-            if (!Statics.IsFirefallInstallSteam())
+            // If we have a launcher installation, check for a Firefall update.
+            if (Statics.IsFirefallInstallLauncher())
                 await FirefallUpdate();
 
             // Check for updater and remove it if it is there.

--- a/Meldii/Statics.cs
+++ b/Meldii/Statics.cs
@@ -83,6 +83,42 @@ namespace Meldii
 
         }
 
+        public static bool IsFirefallInstallLauncher()
+        {
+            string install = String.Empty;
+            bool launcher = false;
+
+            var view = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32);
+            using (var firefall = view.OpenSubKey(@"Software\Red 5 Studios\Firefall_Beta"))
+            {
+                if (firefall != null)
+                {
+                    install = Path.GetFullPath((string)firefall.GetValue("InstallLocation", String.Empty)).ToLowerInvariant();
+                    if (!String.IsNullOrWhiteSpace(install))
+                        launcher = true;
+                }
+            }
+
+            if (!launcher)
+                return false;
+
+            // Find our Steam install location to see if our launcher might be a Steam version.
+            // This should handle most cases.  Steam can have multiple library locations now, but I
+            // have no idea how to test for that.
+            view = RegistryKey.OpenBaseKey(RegistryHive.CurrentUser, RegistryView.Default);
+            using (var steam = view.OpenSubKey(@"Software\Valve\Steam"))
+            {
+                if (steam != null)
+                {
+                    string steamInstall = Path.GetFullPath((string)steam.GetValue("SteamPath", String.Empty)).ToLowerInvariant();
+                    if (!String.IsNullOrEmpty(steamInstall) && install.StartsWith(steamInstall))
+                        launcher = false;
+                }
+            }
+
+            return launcher;
+        }
+
         public static bool IsFirefallInstallSteam()
         {
             var view = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32);


### PR DESCRIPTION
If a user has both the Steam version and the standard version installed, this will let Meldii properly inform when they can update the standard install, in most situations.
