### PR TITLE
Fix Melder One-Click Install setting to spawn an admin process, among others.

### DIFF
--- a/Meldii/App.xaml.cs
+++ b/Meldii/App.xaml.cs
@@ -21,6 +21,7 @@ namespace Meldii
             string[] lines = 
             {
                 ".Net Runtime Version: " + Environment.Version.ToString(),
+                "OS: " + Environment.OSVersion.ToString(),
                 "Source: " + e.Exception.Source,
                 "Target: " + e.Exception.TargetSite,
                 "Message: " + e.Exception.Message,

--- a/Meldii/MainWindow.xaml.cs
+++ b/Meldii/MainWindow.xaml.cs
@@ -79,7 +79,14 @@ namespace Meldii
             try
             {
                 Process.Start(info);
-                //Application.Exit();
+
+                if (MeldiiSettings.Self.CloseMeldiiOnFirefallLaunch)
+                {
+                    App.Current.Dispatcher.Invoke((Action)delegate()
+                    {
+                        Application.Current.Shutdown();
+                    });
+                }
             }
             catch (System.ComponentModel.Win32Exception)
             {

--- a/Meldii/Meldii.DataStructures/MeldiiSettings.cs
+++ b/Meldii/Meldii.DataStructures/MeldiiSettings.cs
@@ -11,7 +11,8 @@ namespace Meldii.DataStructures
 
         public string FirefallInstallPath = "";
         public string AddonLibaryPath = "";
-        public bool IsMelderProtcolEnabled = false;
+        public bool IsMelderProtocolEnabled = false;
+        public bool CloseMeldiiOnFirefallLaunch = true;
         public string Theme;
         public string ThemeAccent;
 

--- a/Meldii/Meldii.Windows/SettingsFlyout.xaml
+++ b/Meldii/Meldii.Windows/SettingsFlyout.xaml
@@ -52,9 +52,16 @@
                         <Button Content="Find" Width="45" HorizontalAlignment="Right" VerticalAlignment="Top" Click="Btt_AddonLibFind" Grid.Column="1"/>
                     </Grid>
 
-                    <CheckBox Content="Enable Melder One Click Downloads" IsChecked="{Binding IsMelderProtcolEnabled}" VerticalAlignment="Top" Margin="0,5,5,0"/>
-                    
-                    <Button Content="Save Settings" Width="auto" VerticalAlignment="Top" Margin="0,10,0,0" Click="Btt_SaveSettings"/>
+                    <CheckBox Content="Enable Melder One Click Downloads" IsChecked="{Binding IsMelderProtocolEnabled}" VerticalAlignment="Top" Margin="0,5,5,0"/>
+
+                    <CheckBox Content="Close Meldii on Firefall Launch" IsChecked="{Binding CloseMeldiiOnFirefallLaunch}" VerticalAlignment="Top" Margin="0,5,5,0"/>
+
+                    <Button Width="auto" VerticalAlignment="Top" Margin="0,10,0,0" Click="Btt_SaveSettings">
+                        <StackPanel Orientation="Horizontal">
+                            <Image MaxHeight="12" MaxWidth="12" Margin="0,0,10,0" Name="Img_UAC" />
+                            <TextBlock Margin="0,0,10,0">Save Settings</TextBlock>
+                        </StackPanel>
+                    </Button>
                 </StackPanel>
             </Expander>
 

--- a/Meldii/Meldii.Windows/SettingsFlyout.xaml.cs
+++ b/Meldii/Meldii.Windows/SettingsFlyout.xaml.cs
@@ -32,7 +32,7 @@ namespace Meldii.Windows
         private void Btt_AddonLibFind(object sender, RoutedEventArgs e)
         {
             FolderBrowserDialog fbd = new FolderBrowserDialog();
-           fbd.SelectedPath = View.AddonLibaryPath;
+            fbd.SelectedPath = View.AddonLibaryPath;
             var res = fbd.ShowDialog();
             View.AddonLibaryPath = fbd.SelectedPath;
         }

--- a/Meldii/SelfUpdater.cs
+++ b/Meldii/SelfUpdater.cs
@@ -69,8 +69,8 @@ namespace Meldii
 
         private static async void UpdateChecks()
         {
-            // If we aren't using a Steam install, check for a Firefall update.
-            if (!Statics.IsFirefallInstallSteam())
+            // If we have a launcher installation, check for a Firefall update.
+            if (Statics.IsFirefallInstallLauncher())
                 await FirefallUpdate();
 
             // Check for updater and remove it if it is there.

--- a/Meldii/Statics.cs
+++ b/Meldii/Statics.cs
@@ -83,6 +83,42 @@ namespace Meldii
 
         }
 
+        public static bool IsFirefallInstallLauncher()
+        {
+            string install = String.Empty;
+            bool launcher = false;
+
+            var view = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32);
+            using (var firefall = view.OpenSubKey(@"Software\Red 5 Studios\Firefall_Beta"))
+            {
+                if (firefall != null)
+                {
+                    install = Path.GetFullPath((string)firefall.GetValue("InstallLocation", String.Empty)).ToLowerInvariant();
+                    if (!String.IsNullOrWhiteSpace(install))
+                        launcher = true;
+                }
+            }
+
+            if (!launcher)
+                return false;
+
+            // Find our Steam install location to see if our launcher might be a Steam version.
+            // This should handle most cases.  Steam can have multiple library locations now, but I
+            // have no idea how to test for that.
+            view = RegistryKey.OpenBaseKey(RegistryHive.CurrentUser, RegistryView.Default);
+            using (var steam = view.OpenSubKey(@"Software\Valve\Steam"))
+            {
+                if (steam != null)
+                {
+                    string steamInstall = Path.GetFullPath((string)steam.GetValue("SteamPath", String.Empty)).ToLowerInvariant();
+                    if (!String.IsNullOrEmpty(steamInstall) && install.StartsWith(steamInstall))
+                        launcher = false;
+                }
+            }
+
+            return launcher;
+        }
+
         public static bool IsFirefallInstallSteam()
         {
             var view = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32);


### PR DESCRIPTION
Spawns an admin process to handle creating/deleting registry keys when dealing with the Melder One-Click Install setting.
Added a new setting to automatically close Meldii when Firefall is launched.

I made a mistake and my other branch, fix-steam-update, got merged into this one and I don't know how to fix.  Welp.
